### PR TITLE
Update minimum PHP version to 5.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     }],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.2"
     },
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.1.0",


### PR DESCRIPTION
bin/validate-json uses stream_resolve_include_path()
which is only available in PHP >= 5.3.2
